### PR TITLE
Handle multiple fields with the same name

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,13 +37,11 @@ function build() {
 }
 
 function sendToCoveralls() {
-  require('babel-core/register');
   gulp.src('coverage/**/lcov.info')
   .pipe(coveralls());
 }
 
 function runMochaTests() {
-  require('babel-core/register');
   return gulp.src('test/unit/**/*.js', {read: false})
     .pipe(mocha({
        reporter: 'dot',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formwood",
-  "version": "0.0.14",
+  "version": "0.1.0",
   "main": "dist/formwood.js",
   "repository": {
     "type": "git",

--- a/src/field.js
+++ b/src/field.js
@@ -7,7 +7,8 @@ export default function(WrappedComponent) {
       return {
         value: this.props.value,
         message: this.props.message,
-        valid: true
+        valid: true,
+        timestamp: 0
       };
     },
 
@@ -35,6 +36,8 @@ export default function(WrappedComponent) {
     },
 
     handleChange(event) {
+      this.setState({timestamp: Date.now()});
+
       return new Promise((resolve) => {
         switch (event.target.type) {
           case 'checkbox':

--- a/src/form.js
+++ b/src/form.js
@@ -17,8 +17,8 @@ export default React.createClass({
     return new Promise((resolve) => {
       this.invalidFields = {};
       for (let fieldName in this.fields) {
-        let field = this.fields[fieldName];
-        if (!field.validate()) {
+        let field = this.getField(this.fields[fieldName]);
+        if (field && !field.validate()) {
           this.invalidFields[fieldName] = field;
         }
       }
@@ -41,10 +41,19 @@ export default React.createClass({
       });
   },
 
+  getField(fields) {
+    return fields.sort((a, b) => {
+      return b.state.timestamp - a.state.timestamp;
+    })[0];
+  },
+
   values() {
     let values = {};
     for (let fieldName in this.fields) {
-      values[fieldName] = this.fields[fieldName].state.value;
+      let field = this.getField(this.fields[fieldName]);
+      if (field && field.state.value) {
+        values[fieldName] = field.state.value;
+      }
     }
     return values;
   },
@@ -66,7 +75,16 @@ export default React.createClass({
 
   children() {
     let fields = {};
-    const ref = {ref: (field) => { if (field) { fields[field.props.name] = field;} }};
+    const ref = {
+      ref: (field) => {
+        if (field) {
+          if (!fields[field.props.name]) {
+            fields[field.props.name] = [];
+          }
+          fields[field.props.name].push(field);
+        }
+      }
+    };
     const children = this.addPropsToChildren(this.props.children, ref);
     this.fields = fields;
     return children;


### PR DESCRIPTION
This solution allows the use of multiple fields with the same name prop, commonly used in a group of radio buttons.

Fields now save a timestamp in the `handleChange` handler which allows the form to use the field with the most recently selected value. This method allows fields to remain unaware of the form and other field components.
