### PR TITLE
Don't set defaultValue with the state value. Closes #18

### DIFF
--- a/src/field.js
+++ b/src/field.js
@@ -68,7 +68,7 @@ export default function(WrappedComponent) {
     elementProps() {
       const elementProps = Object.assign({
         defaultChecked: this.props.value === this.props.initialValue,
-        defaultValue: this.props.value || this.state.value,
+        defaultValue: this.props.value || this.props.initialValue,
         onChange: this.handleChange
       }, this.props);
 


### PR DESCRIPTION
This is only partially fixed. I no longer set `defaultValue` to `this.state.value`, which removes  the warnings while typing in an empty email field. Warnings will still show if the field has an initial value. There is an issue open regarding this problem here: https://github.com/facebook/react/issues/7487
