### PR TITLE
Tests and some bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formwood",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "main": "dist/formwood.js",
   "repository": {
     "type": "git",

--- a/src/field.js
+++ b/src/field.js
@@ -57,8 +57,9 @@ export default function(WrappedComponent) {
           case 'select-multiple':
             this.setState({
               value: Array.from(event.target.options).map((option) => {
-                if (option.selected) { return option.value; }
-              }).filter((value) => { return value; })
+                return option.selected ? option.value : null;
+              })
+              .filter((value) => { return value; })
             }, resolve);
             break;
           default:

--- a/src/field.js
+++ b/src/field.js
@@ -55,10 +55,13 @@ export default function(WrappedComponent) {
             }, resolve);
             break;
           case 'select-multiple':
-            this.setState({
-              value: Array.from(event.target.selectedOptions).map((option) => {
-                return option.value;
-              })}, resolve);
+            let values = [];
+            Array.from(event.target.options).forEach((option) => {
+              if (option.selected) {
+                values.push(option.value);
+              }
+            });
+            this.setState({value: values}, resolve);
             break;
           default:
             this.setState({value: event.target.value}, resolve);

--- a/src/field.js
+++ b/src/field.js
@@ -24,13 +24,8 @@ export default function(WrappedComponent) {
       }
     },
 
-    componentDidUpdate(prevProps) {
-      if (prevProps.value !== this.props.value) {
-        this.setState({value: this.props.value});
-      }
-      if (prevProps.message !== this.props.message) {
-        this.setState({message: this.props.message});
-      }
+    componentWillReceiveProps(nextProps) {
+      this.setState({message: nextProps.message});
     },
 
     validate() {

--- a/src/field.js
+++ b/src/field.js
@@ -55,13 +55,11 @@ export default function(WrappedComponent) {
             }, resolve);
             break;
           case 'select-multiple':
-            let values = [];
-            Array.from(event.target.options).forEach((option) => {
-              if (option.selected) {
-                values.push(option.value);
-              }
-            });
-            this.setState({value: values}, resolve);
+            this.setState({
+              value: Array.from(event.target.options).map((option) => {
+                if (option.selected) { return option.value; }
+              }).filter((value) => { return value; })
+            }, resolve);
             break;
           default:
             this.setState({value: event.target.value}, resolve);

--- a/src/field.js
+++ b/src/field.js
@@ -3,6 +3,10 @@ import React from 'react';
 
 export default function(WrappedComponent) {
   const Field = React.createClass({
+    propTypes: {
+      name: React.PropTypes.string.isRequired
+    },
+
     getInitialState() {
       return {
         checked: this.checked(),

--- a/test/fields.js
+++ b/test/fields.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Field from '../src/field';
+import {required} from './validators';
 
 
 const InputField = Field(React.createClass({
@@ -10,4 +11,33 @@ const InputField = Field(React.createClass({
   }
 }));
 
-export {InputField};
+const RequiredInputField = Field(React.createClass({
+  validators: [required()],
+
+  render() {
+    return (
+      <input {...this.props.element}/>
+    );
+  }
+}));
+
+const SelectField = Field(React.createClass({
+  options() {
+    return this.props.element.options.map((option) => {
+      return <option key={option}>{option}</option>;
+    });
+  },
+
+  render() {
+    let elementProps = Object.assign({}, this.props.element);
+    delete elementProps.options;
+
+    return (
+      <select {...elementProps}>
+        {this.options()}
+      </select>
+    );
+  }
+}));
+
+export {InputField, RequiredInputField, SelectField};

--- a/test/unit/field.js
+++ b/test/unit/field.js
@@ -4,8 +4,8 @@ import simpleJSDOM from 'simple-jsdom';
 import {expect} from 'chai';
 import {mount} from 'enzyme';
 import Form from '../../src/form';
-import {InputField} from '../fields';
-import {required} from '../validators';
+import {InputField, SelectField, RequiredInputField} from '../fields';
+import {required, minLength} from '../validators';
 
 
 simpleJSDOM.install();
@@ -64,32 +64,117 @@ describe('Field', function() {
     });
   });
 
+  describe('with a validator defined in the wrapped component', () => {
+    beforeEach(() => {
+      this.wrapper = mount(
+        <Form>
+          <RequiredInputField name="banana" type="text"/>
+        </Form>
+      );
+      this.field = this.wrapper.instance().getField('banana');
+    });
+
+    it('should be invalid without a value', () => {
+      expect(this.field.validate()).to.be.false;
+    });
+
+    it('should be valid with a value', () => {
+      const event = {
+        type: 'change',
+        target: {value: 'peel'}
+      };
+      return this.field.handleChange(event)
+        .then(() => {
+          expect(this.field.validate()).to.be.true;
+        });
+    });
+
+    describe('and on the component tag', () => {
+      beforeEach(() => {
+        this.wrapper = mount(
+          <Form>
+            <RequiredInputField name="banana" type="text" validators={[minLength(5)]}/>
+          </Form>
+        );
+        this.field = this.wrapper.instance().getField('banana');
+      });
+
+      it('should have two validators', () => {
+        expect(this.field.validators).to.have.length(2);
+      });
+
+      it('should be invalid without a value', () => {
+        expect(this.field.validate()).to.be.false;
+      });
+
+      it('should be invalid with a value under 5 characters', () => {
+        const event = {
+          type: 'change',
+          target: {value: 'peel'}
+        };
+        return this.field.handleChange(event)
+          .then(() => {
+            expect(this.field.validate()).to.be.false;
+          });
+      });
+
+      it('should be valid with a value with 5 characters', () => {
+        const event = {
+          type: 'change',
+          target: {value: 'puree'}
+        };
+        return this.field.handleChange(event)
+          .then(() => {
+            expect(this.field.validate()).to.be.true;
+          });
+      });
+    });
+  });
+
   describe('with initial values', () => {
     beforeEach(() => {
       const initialValues = {
         'banana': {value: 'peel'},
         'grape': {value: true},
-        'fruit': {value: 'pear'}
+        'fruit': {value: 'pear'},
+        'colour': {value: 'green'},
+        'colours': {value: ['cyan', 'yellow']},
       };
       this.wrapper = mount(
         <Form values={initialValues}>
           <InputField name="banana" type="text"/>
           <InputField name="grape" type="checkbox"/>
           <InputField name="fruit" type="checkbox" value="pear"/>
+          <SelectField name="colour" options={['red', 'green', 'blue']}/>
+          <SelectField name="colours" options={['cyan', 'magenta', 'yellow']} multiple={true}/>
         </Form>
       );
       this.textField = this.wrapper.instance().getField('banana');
       this.checkboxField1 = this.wrapper.instance().getField('grape');
       this.checkboxField2 = this.wrapper.instance().getField('fruit');
+      this.selectField1 = this.wrapper.instance().getField('colour');
+      this.selectField2 = this.wrapper.instance().getField('colours');
     });
 
     it('should have an initial value', () => {
       expect(findDOMNode(this.textField).value).to.equal('peel');
+      expect(findDOMNode(this.selectField1).value).to.equal('green');
     });
 
     it('should be checked', () => {
       expect(findDOMNode(this.checkboxField1).checked).to.be.true;
       expect(findDOMNode(this.checkboxField2).checked).to.be.true;
+    });
+
+    it('should have an array if multiple is true', () => {
+      let values = [];
+      Array.from(findDOMNode(this.selectField2).children).forEach((option) => {
+        if (option.selected) {
+          values.push(option.value);
+        }
+      });
+      expect(values[0]).to.equal('cyan');
+      expect(values[1]).to.equal('yellow');
     });
   });
 
@@ -150,10 +235,96 @@ describe('Field', function() {
     beforeEach(() => {
       this.wrapper = mount(
         <Form>
-          <InputField name="grape" type="radio"/>
+          <InputField name="grape" type="radio" value="grape"/>
         </Form>
       );
       this.field = this.wrapper.instance().getField('grape');
+    });
+
+    it('should not have a value', () => {
+      expect(this.field.state.value).to.be.undefined;
+    });
+
+    it('should have a value after being checked', () => {
+      const event = {
+        type: 'change',
+        target: {
+          checked: true,
+          type: 'radio',
+          value: 'grape'
+        }
+      };
+      return this.field.handleChange(event)
+        .then(() => {
+          expect(this.field.state.value).to.equal('grape');
+        });
+    });
+  });
+
+  describe('of type select', () => {
+    describe('with multiple set to false', () => {
+      beforeEach(() => {
+        this.wrapper = mount(
+          <Form>
+            <SelectField name="fruit" options={['apple', 'banana', 'cranberry']}/>
+          </Form>
+        );
+        this.field = this.wrapper.instance().getField('fruit');
+      });
+
+      it('should not have a value', () => {
+        expect(this.field.state.value).to.be.undefined;
+      });
+
+      it('should have a value after being changed', () => {
+        const event = {
+          type: 'change',
+          target: {
+            value: 'banana'
+          }
+        };
+        return this.field.handleChange(event)
+          .then(() => {
+            expect(this.field.state.value).to.equal('banana');
+          });
+      });
+    });
+    describe('with multiple set to true', () => {
+      beforeEach(() => {
+        this.wrapper = mount(
+          <Form>
+            <SelectField name="fruits" options={['apple', 'banana', 'cranberry']} multiple={true}/>
+          </Form>
+        );
+        this.field = this.wrapper.instance().getField('fruits');
+      });
+
+      it('should not have a value', () => {
+        expect(this.field.state.value).to.be.undefined;
+      });
+
+      it('should have a value after being changed', () => {
+        this.options = findDOMNode(this.field).options;
+        this.options[1].selected = true;
+        const event = {
+          type: 'change',
+          target: {
+            type: 'select-multiple',
+            value: 'banana',
+            options: this.options
+          }
+        };
+        return this.field.handleChange(event)
+        .then(() => {
+          expect(this.field.state.value).to.deep.equal(['banana']);
+          this.options[2].selected = true;
+          event.target.value = 'cranberry';
+          return this.field.handleChange(event)
+          .then(() => {
+            expect(this.field.state.value).to.deep.equal(['banana', 'cranberry']);
+          });
+        });
+      });
     });
   });
 });

--- a/test/unit/form.js
+++ b/test/unit/form.js
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import {mount} from 'enzyme';
 import Form from '../../src/form';
-import {InputField} from '../fields';
+import {InputField, SelectField} from '../fields';
 import {required} from '../validators';
 
 chai.use(sinonChai);
@@ -17,6 +17,7 @@ describe('Form', function() {
     beforeEach(() => {
       this.wrapper = mount(
         <Form>
+          <h1>Test</h1>
           <InputField name="banana" type="text"/>
         </Form>
       );
@@ -358,9 +359,11 @@ describe('Form', function() {
   describe('with initial form values', () => {
     beforeEach(() => {
       const initialValues = {
-        'banana': {value: 'peel'},
-        'pear': {value: 'juice'},
-        'fruits': {value: ['mango', 'papaya']}
+        banana: {value: 'peel'},
+        pear: {value: 'juice'},
+        fruits: {value: ['mango', 'papaya']},
+        colour: {value: 'blue'},
+        colours: {value: ['cyan', 'yellow']}
       };
       this.wrapper = mount(
         <Form values={initialValues}>
@@ -373,15 +376,19 @@ describe('Form', function() {
             <InputField name="fruits" type="checkbox" value="mango"/>
             <InputField name="fruits" type="checkbox" value="papaya"/>
           </fieldset>
+          <SelectField name="colour" options={['red', 'green', 'blue']}/>
+          <SelectField name="colours" options={['cyan', 'magenta', 'yellow']} multiple={true}/>
         </Form>
       );
     });
 
     it('should have the correct values', () => {
       expect(this.wrapper.instance().values()).to.deep.equal({
-        'banana': 'peel',
-        'pear': 'juice',
-        'fruits': ['mango', 'papaya']
+        banana: 'peel',
+        pear: 'juice',
+        fruits: ['mango', 'papaya'],
+        colour: 'blue',
+        colours: ['cyan', 'yellow']
       });
     });
   });

--- a/test/validators.js
+++ b/test/validators.js
@@ -7,4 +7,13 @@ function required() {
   };
 }
 
-export {required};
+function minLength(length) {
+  return (value) => {
+    if (value && value.length >= length) {
+      return true;
+    }
+    return `Must be at least ${length} characters`
+  };
+}
+
+export {required, minLength};


### PR DESCRIPTION
I changed the method for getting values in the `select-multiple` change event. I was using `selectedOptions` but recently learned that it is not supported in Internet Explorer, so I changed it to `options` and check each one for `selected`.

I also replaced the `componentDidUpdate` in `Field` to `componentWillReceiveProps`. I no longer set `value` when the prop changes (i.e. updating the initial form values) because that was causing inputs to become `controlled` and broke functionality. You can still set initial values on a form, you just can't change them after the form has rendered. You can still change `message` at any time.
