### PR TITLE
Field refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formwood",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist/formwood.js",
   "repository": {
     "type": "git",

--- a/src/field.js
+++ b/src/field.js
@@ -89,10 +89,10 @@ export default function(WrappedComponent) {
 
       delete elementProps.checked;
       delete elementProps.initialValue;
+      delete elementProps.label;
       delete elementProps.message;
       delete elementProps.validators;
       delete elementProps.value;
-
       return elementProps;
     },
 
@@ -100,11 +100,10 @@ export default function(WrappedComponent) {
       return (
         <WrappedComponent
           element={this.elementProps()}
-          label={this.props.label}
+          {...this.props}
           message={this.state.message}
           validate={this.validate}
           value={this.state.value}
-          initialValue={this.props.initialValue}
           ref={(component) => { this.component = component;}}
         />
       );


### PR DESCRIPTION
Add all of `this.props` to the WrappedComponent. I couldn't see a good reason not to do this. I'm deleting `label` from the `elementProps` object since it is so frequently used.
