### PR TITLE
Update getCheckboxValues to only return an array

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -55,9 +55,6 @@ export default React.createClass({
         fieldValues.push(field.state.value);
       }
     }
-    if (fieldValues.length === 1) {
-      fieldValues = fieldValues[0];
-    }
     return fieldValues;
   },
 
@@ -68,7 +65,10 @@ export default React.createClass({
       switch (field.state.type) {
         case 'checkbox': {
           let fieldValues = this.getCheckboxValues(fieldName);
-          if (fieldValues.length) {
+          if (fieldValues.length === 1) {
+            values[fieldName] = fieldValues[0];
+          }
+          else if (fieldValues.length > 1) {
             values[fieldName] = fieldValues;
           }
           break;


### PR DESCRIPTION
`getCheckboxValues` used to return the value of the first element if the array had a length of one. I moved that length check logic into the `values` function so that `getCheckboxValues` doesn't have multiple return types. I think it is clearer this way and returns the value its name suggests.
