### PR TITLE
Change method of registering fields in a form

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formwood",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "main": "dist/formwood.js",
   "repository": {
     "type": "git",

--- a/src/field.js
+++ b/src/field.js
@@ -18,6 +18,7 @@ export default function(WrappedComponent) {
     },
 
     componentDidMount() {
+      this.props.registerField(this);
       this.validators = this.props.validators || [];
       if (this.component && this.component.validators) {
         this.validators = this.component.validators.concat(this.validators);
@@ -93,6 +94,7 @@ export default function(WrappedComponent) {
       delete elementProps.initialValue;
       delete elementProps.label;
       delete elementProps.message;
+      delete elementProps.registerField;
       delete elementProps.validators;
       delete elementProps.value;
       return elementProps;

--- a/src/form.js
+++ b/src/form.js
@@ -92,7 +92,7 @@ export default React.createClass({
       let childProps = {};
       if (child.props) {
         childProps.children = this.addPropsToChildren(child.props.children, props);
-        if (child.type.displayName === 'Field') {
+        if (child.type.constructor === Function) {
           const values = {
             initialValue: this.props.values[child.props.name],
             message: this.props.messages[child.props.name]

--- a/src/form.js
+++ b/src/form.js
@@ -2,8 +2,10 @@ import React from 'react';
 
 
 export default React.createClass({
-  fields: {},
-  invalidFields: {},
+  componentWillMount() {
+    this.fields = {};
+    this.invalidFields = {};
+  },
 
   getInitialState() {
     return {valid: true};
@@ -105,31 +107,27 @@ export default React.createClass({
     });
   },
 
-  children() {
-    let fields = {};
-    const ref = {
-      ref: (field) => {
-        if (field) {
-          if (!fields[field.props.name]) {
-            fields[field.props.name] = [];
-          }
-          fields[field.props.name].push(field);
+  registerField() {
+    return {
+      registerField: (field) => {
+        const name = field.props.name;
+        if (!this.fields[name]) {
+          this.fields[name] = [];
         }
+        this.fields[field.props.name].push(field)
       }
-    };
-    const children = this.addPropsToChildren(this.props.children, ref);
-    this.fields = fields;
-    return children;
+    }
   },
 
   render() {
+    const children = this.addPropsToChildren(this.props.children, this.registerField());
     let formProps = Object.assign({}, this.props);
     delete formProps.values;
     delete formProps.messages;
 
     return (
       <form {...formProps} onSubmit={this.handleSubmit}>
-        {this.children()}
+        {children}
       </form>
     );
   }

--- a/src/form.js
+++ b/src/form.js
@@ -114,9 +114,9 @@ export default React.createClass({
         if (!this.fields[name]) {
           this.fields[name] = [];
         }
-        this.fields[field.props.name].push(field)
+        this.fields[field.props.name].push(field);
       }
-    }
+    };
   },
 
   render() {


### PR DESCRIPTION
Instead of registering fields by adding a `ref` prop to the Form's children, it adds a `registerField` callback prop. This allows nesting of fields inside components. For this to work, a component that is a child of the Form, must pass it's `registerField` prop to the field. I imagine this can usually be done by using the spread operator `{...this.props}`.