### PR TITLE
Use event.timeStamp instead of Date.now()

### DIFF
--- a/src/field.js
+++ b/src/field.js
@@ -52,7 +52,7 @@ export default function(WrappedComponent) {
     handleChange(event) {
       this.setState({
         type: event.target.type,
-        timestamp: Date.now()
+        timestamp: event.timeStamp
       });
 
       return new Promise(resolve => {

--- a/test/unit/form.js
+++ b/test/unit/form.js
@@ -163,12 +163,14 @@ describe('Form', function() {
       it('should return the most recently changed field', () => {
         const event = {
           type: 'change',
-          target: {value: 'peel'}
+          target: {value: 'peel'},
+          timeStamp: 1
         };
 
         let fields = this.wrapper.instance().fields.banana;
         this.wrapper.instance().fields.banana[0].handleChange(event);
         this.clock.tick(100);
+        event.timeStamp = 2;
         return this.wrapper.instance().fields.banana[1].handleChange(event)
           .then(() => {
             let field = this.wrapper.instance().fields.banana[1];
@@ -285,6 +287,7 @@ describe('Form', function() {
       beforeEach(() => {
         this.event1 = {
           type: 'change',
+          timeStamp: 1,
           target: {
             checked: true,
             type: 'checkbox',
@@ -293,6 +296,7 @@ describe('Form', function() {
         };
         this.event2 = {
           type: 'change',
+          timeStamp: 2,
           target: {
             checked: true,
             type: 'checkbox',


### PR DESCRIPTION
I'd like to use [event.timeStamp](https://developer.mozilla.org/en-US/docs/Web/API/Event/timeStamp) instead of creating a timestamp with `Date.now()`. It seems cleaner to me to use an already-created timestamp than to create a new one. 
Also, it looks like Chrome [improved event timestamp accuracy](https://developers.google.com/web/updates/2016/01/high-res-timestamps) a couple years ago.