### PR TITLE
Remove ability to set validators on the component

### DIFF
--- a/src/field.js
+++ b/src/field.js
@@ -20,11 +20,6 @@ export default function(WrappedComponent) {
 
     componentDidMount() {
       this.props.form.registerField(this);
-
-      this.validators = this.props.validators || [];
-      if (this.component && this.component.validators) {
-        this.validators = this.component.validators.concat(this.validators);
-      }
     }
 
     componentWillUnmount() {
@@ -38,7 +33,7 @@ export default function(WrappedComponent) {
     }
 
     validate() {
-      for (const validator of this.validators) {
+      for (const validator of this.props.validators) {
         const result = validator(this.state.value);
         if (result !== undefined) {
           this.setState({valid: false, message: result});
@@ -116,7 +111,6 @@ export default function(WrappedComponent) {
           valid={this.state.valid}
           validate={this.validate}
           value={this.state.value}
-          ref={component => { this.component = component;}}
         />
       );
     }
@@ -124,6 +118,10 @@ export default function(WrappedComponent) {
 
   Field.propTypes = {
     name: PropTypes.string.isRequired
+  };
+
+  Field.defaultProps = {
+    validators: []
   };
 
   return Field;

--- a/test/fields.js
+++ b/test/fields.js
@@ -13,21 +13,6 @@ const InputField = Field(
   }
 );
 
-const RequiredInputField = Field(
-  class extends React.Component {
-    constructor(props) {
-      super(props);
-      this.validators = [required()];
-    }
-
-    render() {
-      return (
-        <input {...this.props.element}/>
-      );
-    }
-  }
-);
-
 const SelectField = Field(
   class extends React.Component {
     options() {
@@ -49,4 +34,4 @@ const SelectField = Field(
   }
 );
 
-export {InputField, RequiredInputField, SelectField};
+export {InputField, SelectField};

--- a/test/unit/field.js
+++ b/test/unit/field.js
@@ -8,7 +8,7 @@ import Enzyme from 'enzyme';
 import {mount} from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import Form from '../../src/form';
-import {InputField, SelectField, RequiredInputField} from '../fields';
+import {InputField, SelectField } from '../fields';
 import {required, minLength} from '../validators';
 
 Enzyme.configure({ adapter: new Adapter() });
@@ -109,73 +109,6 @@ describe('Field', function() {
         .then(() => {
           expect(this.field.validate()).to.be.true;
         });
-    });
-  });
-
-  describe('with a validator defined in the wrapped component', () => {
-    beforeEach(() => {
-      this.wrapper = mount(
-        <Form>
-          <RequiredInputField name="banana" type="text"/>
-        </Form>
-      );
-      this.field = this.wrapper.instance().getField('banana');
-    });
-
-    it('should be invalid without a value', () => {
-      expect(this.field.validate()).to.be.false;
-    });
-
-    it('should be valid with a value', () => {
-      const event = {
-        type: 'change',
-        target: {value: 'peel'}
-      };
-      return this.field.handleChange(event)
-        .then(() => {
-          expect(this.field.validate()).to.be.true;
-        });
-    });
-
-    describe('and on the component tag', () => {
-      beforeEach(() => {
-        this.wrapper = mount(
-          <Form>
-            <RequiredInputField name="banana" type="text" validators={[minLength(5)]}/>
-          </Form>
-        );
-        this.field = this.wrapper.instance().getField('banana');
-      });
-
-      it('should have two validators', () => {
-        expect(this.field.validators).to.have.length(2);
-      });
-
-      it('should be invalid without a value', () => {
-        expect(this.field.validate()).to.be.false;
-      });
-
-      it('should be invalid with a value under 5 characters', () => {
-        const event = {
-          type: 'change',
-          target: {value: 'peel'}
-        };
-        return this.field.handleChange(event)
-          .then(() => {
-            expect(this.field.validate()).to.be.false;
-          });
-      });
-
-      it('should be valid with a value with 5 characters', () => {
-        const event = {
-          type: 'change',
-          target: {value: 'puree'}
-        };
-        return this.field.handleChange(event)
-          .then(() => {
-            expect(this.field.validate()).to.be.true;
-          });
-      });
     });
   });
 


### PR DESCRIPTION
My preference is to keep things simple and only provide one way of accomplishing a task, if possible. I don't think this feature is worth keeping around. It wasn't documented at all so I would be surprised if anyone was even making use of it.